### PR TITLE
Prevent email clash when using multiple clusters

### DIFF
--- a/templates/commandline.tmpl
+++ b/templates/commandline.tmpl
@@ -57,14 +57,14 @@ $ sudo mv ./kubectl /usr/local/bin/kubectl
                <code class="language-bash">
 echo "{{ .ClusterCA }}" \ > ca-{{ .ClusterName }}.pem
 kubectl config set-cluster {{ .ClusterName }} --server={{ .APIServerURL }} --certificate-authority=ca-{{ .ClusterName }}.pem --embed-certs
-kubectl config set-credentials {{ .Email }}  \
+kubectl config set-credentials {{ .Email }}@{{ .ClusterName }}  \
     --auth-provider=oidc  \
     --auth-provider-arg='idp-issuer-url={{ .IssuerURL }}'  \
     --auth-provider-arg='client-id={{ .ClientID }}'  \
     --auth-provider-arg='client-secret={{ .ClientSecret }}' \
     --auth-provider-arg='refresh-token={{ .RefreshToken }}' \
     --auth-provider-arg='id-token={{ .IDToken }}'
-kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Email }}
+kubectl config set-context {{ .ClusterName }} --cluster={{ .ClusterName }} --user={{ .Email }}@{{ .ClusterName }}
 kubectl config use-context {{ .ClusterName }}
 rm ca-{{ .ClusterName }}.pem
               </code>


### PR DESCRIPTION
This should prevent a person using the same email on different clusters
from overwriting their previous credentials with the generated one by
suffixing the email with the cluster name.